### PR TITLE
refa: improve helm chart for openshift

### DIFF
--- a/charts/steadybit-extension-host/Chart.yaml
+++ b/charts/steadybit-extension-host/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-host
 description: Steadybit host extension Helm chart for Kubernetes.
-version: 1.1.28
+version: 1.1.30
 appVersion: v1.2.25
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-host/templates/_helpers.tpl
+++ b/charts/steadybit-extension-host/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{- /*
+will omit attribute from the passed in object depending on the KubeVersion
+*/}}
+{{- define "omitForKuberVersion" -}}
+{{- $top := index . 0 -}}
+{{- $versionConstraint := index . 1 -}}
+{{- $dict := index . 2 -}}
+{{- $toOmit := index . 3 -}}
+{{- if semverCompare $versionConstraint $top.Capabilities.KubeVersion.Version -}}
+{{- $dict := omit $dict $toOmit -}}
+{{- end -}}
+{{- $dict | toYaml  -}}
+{{- end -}}

--- a/charts/steadybit-extension-host/templates/daemonset.yaml
+++ b/charts/steadybit-extension-host/templates/daemonset.yaml
@@ -114,19 +114,10 @@ spec:
             httpGet:
               path: /health/readiness
               port: {{ .Values.containerPorts.health }}
+          {{- with (include "omitForKuberVersion" (list . "<1.30-0" .Values.containerSecurityContext "appArmorProfile" )) }}
           securityContext:
-            {{- if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version}}
-            appArmorProfile:
-              type: Unconfined
-            {{- end }}
-            seccompProfile:
-              type: Unconfined
-            capabilities:
-              add: {{ toJson .Values.securityContext.capabilities.add }}
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 10000
-            runAsGroup: 10000
+          {{- . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: tmp-dir
           emptyDir: {}

--- a/charts/steadybit-extension-host/templates/scc-clusterrole.yaml
+++ b/charts/steadybit-extension-host/templates/scc-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "system:openshift:scc:{{ .Values.securityContextConstraint.name }}"
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - {{ .Values.securityContextConstraint.name }}
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+{{- end -}}

--- a/charts/steadybit-extension-host/templates/scc-rolebinding.yaml
+++ b/charts/steadybit-extension-host/templates/scc-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "system:openshift:scc:{{ .Values.securityContextConstraint.name }}"
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:openshift:scc:{{ .Values.securityContextConstraint.name }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/steadybit-extension-host/templates/scc.yaml
+++ b/charts/steadybit-extension-host/templates/scc.yaml
@@ -1,0 +1,20 @@
+{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Values.securityContextConstraint.name }}
+priority: null
+allowedCapabilities:
+  {{- .Values.containerSecurityContext.capabilities.add | toYaml | nindent 2 }}
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowHostDirVolumePlugin: true
+allowPrivilegeEscalation: true
+runAsUser:
+  type: MustRunAsNonRoot
+seccompProfiles:
+  - unconfined
+seLinuxContext:
+  type: MustRunAs
+{{- end -}}

--- a/charts/steadybit-extension-host/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/charts/steadybit-extension-host/tests/__snapshot__/daemonset_test.yaml.snap
@@ -72,6 +72,8 @@ manifest should match snapshot using podAnnotations, podLabels and resources:
                   cpu: 200m
                   memory: 256Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -88,9 +90,6 @@ manifest should match snapshot using podAnnotations, podLabels and resources:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -103,6 +102,10 @@ manifest should match snapshot using podAnnotations, podLabels and resources:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -193,6 +196,8 @@ manifest should match snapshot with TLS:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -209,9 +214,6 @@ manifest should match snapshot with TLS:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -227,6 +229,10 @@ manifest should match snapshot with TLS:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -334,9 +340,6 @@ manifest should match snapshot with appArmorProfile for k8s >= 1.30:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -349,6 +352,10 @@ manifest should match snapshot with appArmorProfile for k8s >= 1.30:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -435,6 +442,8 @@ manifest should match snapshot with different containerPorts:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -451,9 +460,6 @@ manifest should match snapshot with different containerPorts:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -466,6 +472,10 @@ manifest should match snapshot with different containerPorts:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -559,6 +569,8 @@ manifest should match snapshot with extra env vars:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -575,9 +587,6 @@ manifest should match snapshot with extra env vars:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -590,6 +599,10 @@ manifest should match snapshot with extra env vars:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -678,6 +691,8 @@ manifest should match snapshot with extra labels:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -694,9 +709,6 @@ manifest should match snapshot with extra labels:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -709,6 +721,10 @@ manifest should match snapshot with extra labels:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -801,6 +817,8 @@ manifest should match snapshot with mutual TLS:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -817,9 +835,6 @@ manifest should match snapshot with mutual TLS:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -838,6 +853,10 @@ manifest should match snapshot with mutual TLS:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -938,6 +957,8 @@ manifest should match snapshot with mutual TLS using containerPaths:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -954,9 +975,6 @@ manifest should match snapshot with mutual TLS using containerPaths:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -969,6 +987,10 @@ manifest should match snapshot with mutual TLS using containerPaths:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -1055,6 +1077,8 @@ manifest should match snapshot with podSecurityContext:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1071,9 +1095,6 @@ manifest should match snapshot with podSecurityContext:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1087,7 +1108,10 @@ manifest should match snapshot with podSecurityContext:
           hostNetwork: true
           hostPID: true
           securityContext:
+            runAsNonRoot: true
             runAsUser: 2222
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -1174,6 +1198,8 @@ manifest should match snapshot with priority class:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1190,9 +1216,6 @@ manifest should match snapshot with priority class:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1206,6 +1229,10 @@ manifest should match snapshot with priority class:
           hostNetwork: true
           hostPID: true
           priorityClassName: my-priority-class
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -1292,6 +1319,8 @@ manifest should match snapshot with update strategy:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1308,9 +1337,6 @@ manifest should match snapshot with update strategy:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1323,6 +1349,10 @@ manifest should match snapshot with update strategy:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}
@@ -1409,6 +1439,8 @@ manifest should match snapshot without TLS:
                   cpu: 50m
                   memory: 16Mi
               securityContext:
+                appArmorProfile:
+                  type: Unconfined
                 capabilities:
                   add:
                     - SYS_ADMIN
@@ -1425,9 +1457,6 @@ manifest should match snapshot without TLS:
                     - SETGID
                     - AUDIT_WRITE
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
                 seccompProfile:
                   type: Unconfined
               volumeMounts:
@@ -1440,6 +1469,10 @@ manifest should match snapshot without TLS:
           dnsPolicy: ClusterFirstWithHostNet
           hostNetwork: true
           hostPID: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: Unconfined
           serviceAccountName: steadybit-extension-host
           volumes:
             - emptyDir: {}

--- a/charts/steadybit-extension-host/tests/__snapshot__/scc_test.yaml.snap
+++ b/charts/steadybit-extension-host/tests/__snapshot__/scc_test.yaml.snap
@@ -1,0 +1,120 @@
+forced rendering on kubernetes:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:openshift:scc:my-scc
+    rules:
+      - apiGroups:
+          - security.openshift.io
+        resourceNames:
+          - my-scc
+        resources:
+          - securitycontextconstraints
+        verbs:
+          - use
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: system:openshift:scc:my-scc
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:openshift:scc:my-scc
+    subjects:
+      - kind: ServiceAccount
+        name: steadybit-extension-host
+        namespace: NAMESPACE
+  3: |
+    allowHostDirVolumePlugin: true
+    allowHostNetwork: true
+    allowHostPID: true
+    allowHostPorts: true
+    allowPrivilegeEscalation: true
+    allowedCapabilities:
+      - SYS_ADMIN
+      - SYS_CHROOT
+      - SYS_RESOURCE
+      - SYS_BOOT
+      - NET_RAW
+      - SYS_TIME
+      - SYS_PTRACE
+      - KILL
+      - NET_ADMIN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - AUDIT_WRITE
+    apiVersion: security.openshift.io/v1
+    kind: SecurityContextConstraints
+    metadata:
+      name: my-scc
+    priority: null
+    runAsUser:
+      type: MustRunAsNonRoot
+    seLinuxContext:
+      type: MustRunAs
+    seccompProfiles:
+      - unconfined
+rendering by default on openshift:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:openshift:scc:steadybit-extension-host
+    rules:
+      - apiGroups:
+          - security.openshift.io
+        resourceNames:
+          - steadybit-extension-host
+        resources:
+          - securitycontextconstraints
+        verbs:
+          - use
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: system:openshift:scc:steadybit-extension-host
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:openshift:scc:steadybit-extension-host
+    subjects:
+      - kind: ServiceAccount
+        name: steadybit-extension-host
+        namespace: NAMESPACE
+  3: |
+    allowHostDirVolumePlugin: true
+    allowHostNetwork: true
+    allowHostPID: true
+    allowHostPorts: true
+    allowPrivilegeEscalation: true
+    allowedCapabilities:
+      - SYS_ADMIN
+      - SYS_CHROOT
+      - SYS_RESOURCE
+      - SYS_BOOT
+      - NET_RAW
+      - SYS_TIME
+      - SYS_PTRACE
+      - KILL
+      - NET_ADMIN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - AUDIT_WRITE
+    apiVersion: security.openshift.io/v1
+    kind: SecurityContextConstraints
+    metadata:
+      name: steadybit-extension-host
+    priority: null
+    runAsUser:
+      type: MustRunAsNonRoot
+    seLinuxContext:
+      type: MustRunAs
+    seccompProfiles:
+      - unconfined

--- a/charts/steadybit-extension-host/tests/scc_test.yaml
+++ b/charts/steadybit-extension-host/tests/scc_test.yaml
@@ -1,0 +1,37 @@
+templates:
+  - scc.yaml
+  - scc-clusterrole.yaml
+  - scc-rolebinding.yaml
+chart:
+  appVersion: v0.0.0
+capabilities:
+  majorVersion: 1
+  minorVersion: 30
+tests:
+  - it: not rendering on kubernetes
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: forced rendering on kubernetes
+    set:
+      securityContextConstraint:
+        create: true
+        name: "my-scc"
+    asserts:
+      - matchSnapshot: {}
+  - it: rendering by default on openshift
+    capabilities:
+      apiVersions:
+        - "security.openshift.io/v1/SecurityContextConstraints"
+    asserts:
+      - matchSnapshot: {}
+  - it: suppressed on openshift
+    capabilities:
+      apiVersions:
+        - "security.openshift.io/v1/SecurityContextConstraints"
+    set:
+      securityContextConstraint:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/steadybit-extension-host/values.yaml
+++ b/charts/steadybit-extension-host/values.yaml
@@ -84,6 +84,11 @@ serviceAccount:
   # serviceAccount.name -- The name of the ServiceAccount to use.
   name: steadybit-extension-host
 
+securityContextConstraint:
+  # securityContextConstraint.create -- Specifies whether a SecurityContextConstraint should be created. Defaults to true if the cluster is OpenShift.
+  create: null
+  name: steadybit-extension-host
+
 # extra labels to apply to the Kubernetes resources
 extraLabels: {}
 
@@ -110,7 +115,33 @@ affinity: {}
 priorityClassName: null
 
 # podSecurityContext -- SecurityContext to apply to the pod.
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: Unconfined
+  runAsNonRoot: true
+
+# containerSecurityContext -- SecurityContext to apply to the container.
+containerSecurityContext:
+  appArmorProfile:
+    type: Unconfined
+  seccompProfile:
+    type: Unconfined
+  readOnlyRootFilesystem: true
+  capabilities:
+    add:
+      - SYS_ADMIN
+      - SYS_CHROOT
+      - SYS_RESOURCE
+      - SYS_BOOT
+      - NET_RAW
+      - SYS_TIME
+      - SYS_PTRACE
+      - KILL
+      - NET_ADMIN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - AUDIT_WRITE
 
 # extraEnv -- Array with extra environment variables to add to the container
 # e.g:
@@ -127,23 +158,6 @@ extraEnv: []
 #  - secretRef:
 #    name: env-secrets
 extraEnvFrom: []
-
-securityContext:
-  capabilities:
-    add:
-      - SYS_ADMIN
-      - SYS_CHROOT
-      - SYS_RESOURCE
-      - SYS_BOOT
-      - NET_RAW
-      - SYS_TIME
-      - SYS_PTRACE
-      - KILL
-      - NET_ADMIN
-      - DAC_OVERRIDE
-      - SETUID
-      - SETGID
-      - AUDIT_WRITE
 
 discovery:
   attributes:


### PR DESCRIPTION
In order to improve installation on openshift, we need to avoid the hard-coded uid/gid in the helm chart