### PR TITLE
fix: use allowed cpus from target container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.7-0.20250131112718-3009f02a4b24
-	github.com/steadybit/action-kit/go/action_kit_commons v1.2.17
+	github.com/steadybit/action-kit/go/action_kit_commons v1.2.18
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.1.14
 	github.com/steadybit/action-kit/go/action_kit_test v1.3.2
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.7-0.20250131112718-3009f02a4b24 h1:yPAEDf9TdBo7AreM9oNguDKqj2aJ4XZsRQupP4x3X9Y=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.7-0.20250131112718-3009f02a4b24/go.mod h1:5Zs3wQtBtda+ASXKYk1sfcDBFe+F2+V2H4EbZzjXhJQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.2.17 h1:NOKvnUA/iZo7mlcgSK+c8EHjxAEYCLSdyk8KVQSXmv8=
-github.com/steadybit/action-kit/go/action_kit_commons v1.2.17/go.mod h1:GFLcaf/WluBIqnq+iSCEGkEqxnfB9h1I16IBR1T7kNQ=
+github.com/steadybit/action-kit/go/action_kit_commons v1.2.18 h1:zg3c7b/Dl0M/odtNMbbhwVn/EbnvPZO14IPwbFy9WbY=
+github.com/steadybit/action-kit/go/action_kit_commons v1.2.18/go.mod h1:GFLcaf/WluBIqnq+iSCEGkEqxnfB9h1I16IBR1T7kNQ=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.1.14 h1:x94RX+vh9Iyc0tS6BhiSpvknj+xE36AV0Nc3D5Yuub0=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.1.14/go.mod h1:Tp/klK5b7k+BCvb3JTSDZSNcnpFBaHauhndzOarnMW4=
 github.com/steadybit/action-kit/go/action_kit_test v1.3.2 h1:DFDznoWEbTGv+fiGYiRaq7tq5es9VTScjrWusRAbS08=


### PR DESCRIPTION
if a process is limited to a certain cpuset or
some of the configured processors are not online, we need to pass the number of workers to stress-ng as otherwise stress-ng will always use the configured number of processors.