### PR TITLE
feat: add tcp reset attack for host targets

### DIFF
--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -65,6 +65,20 @@ var (
 				PortMin: 8443,
 				PortMax: 8443,
 			},
+			{
+				Name:    "kubelet",
+				Url:     "",
+				Cidr:    "0.0.0.0/0",
+				PortMin: 10250,
+				PortMax: 10250,
+			},
+			{
+				Name:    "kubelet",
+				Url:     "",
+				Cidr:    "::/0",
+				PortMin: 10250,
+				PortMax: 10250,
+			},
 		}),
 	}
 	steadybitCIDRs = getCIDRsFor("steadybit.com", 16)
@@ -135,6 +149,10 @@ func TestWithMinikube(t *testing.T) {
 		{
 			Name: "network blackhole",
 			Test: testNetworkBlackhole,
+		},
+		{
+			Name: "network tcp reset",
+			Test: testNetworkTcpReset,
 		},
 		{
 			Name: "network block dns",
@@ -310,39 +328,45 @@ func testTimeTravel(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 }
 
 func getExtensionPodTimeOffset(m *e2e.Minikube, e *e2e.Extension) (time.Duration, error) {
-	var g errgroup.Group
-	chPodTime := make(chan time.Time, 1)
-	chNtpTime := make(chan time.Time, 1)
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		var g errgroup.Group
+		chPodTime := make(chan time.Time, 1)
+		chNtpTime := make(chan time.Time, 1)
 
-	g.Go(func() error {
-		out, err := m.PodExec(e.Pod, "extension", "date", "+%s")
-		if err != nil {
-			return err
+		g.Go(func() error {
+			out, err := m.PodExec(e.Pod, "extension", "date", "+%s")
+			if err != nil {
+				return err
+			}
+
+			epoch := extutil.ToInt64(strings.TrimSpace(out))
+			if epoch == 0 {
+				return fmt.Errorf("failed to get container time")
+			}
+
+			chPodTime <- time.Unix(epoch, 0)
+			return nil
+		})
+
+		g.Go(func() error {
+			ntpTime, err := ntp.Time("pool.ntp.org")
+			if err != nil {
+				return err
+			}
+			chNtpTime <- ntpTime
+			return nil
+		})
+
+		if err := g.Wait(); err != nil {
+			lastErr = err
+			log.Warn().Err(err).Int("attempt", attempt+1).Msg("failed to get time offset, retrying")
+			continue
 		}
 
-		epoch := extutil.ToInt64(strings.TrimSpace(out))
-		if epoch == 0 {
-			return fmt.Errorf("failed to get container time")
-		}
-
-		chPodTime <- time.Unix(epoch, 0)
-		return nil
-	})
-
-	g.Go(func() error {
-		ntpTime, err := ntp.Time("pool.ntp.org")
-		if err != nil {
-			return err
-		}
-		chNtpTime <- ntpTime
-		return nil
-	})
-
-	if err := g.Wait(); err != nil {
-		return 0, err
+		return (<-chPodTime).Sub(<-chNtpTime), nil
 	}
-
-	return (<-chPodTime).Sub(<-chNtpTime), nil
+	return 0, lastErr
 }
 
 func validateDiscovery(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
@@ -466,6 +490,93 @@ func testNetworkBlackhole(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 			nginx.AssertCanReach(t, "https://steadybit.com", true)
 
 			action, err := e.RunAction(exthost.BaseActionID+".network_blackhole", getTarget(m), config, defaultExecutionContext)
+			defer func() { _ = action.Cancel() }()
+			require.NoError(t, err)
+
+			nginx.AssertIsReachable(t, tt.wantedReachable)
+			nginx.AssertCanReach(t, "https://steadybit.com", tt.wantedReachesUrl)
+
+			require.NoError(t, action.Cancel())
+			nginx.AssertIsReachable(t, true)
+			nginx.AssertCanReach(t, "https://steadybit.com", true)
+		})
+	}
+	requireAllSidecarsCleanedUp(t, m, e)
+}
+
+func testNetworkTcpReset(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
+	nginx := e2e.Nginx{Minikube: m}
+	err := nginx.Deploy("nginx-network-tcp-reset")
+	require.NoError(t, err, "failed to create pod")
+	defer func() { _ = nginx.Delete() }()
+
+	tests := []struct {
+		name             string
+		ip               []string
+		hostname         []string
+		port             []string
+		interfaces       []string
+		wantedReachable  bool
+		wantedReachesUrl bool
+	}{
+		{
+			name:             "should reset all traffic",
+			wantedReachable:  false,
+			wantedReachesUrl: false,
+		},
+		{
+			name:             "should reset only port 8080 traffic",
+			port:             []string{"8080"},
+			wantedReachable:  true,
+			wantedReachesUrl: true,
+		},
+		{
+			name:             "should reset only port 80, 443 traffic",
+			port:             []string{"80", "443"},
+			wantedReachable:  false,
+			wantedReachesUrl: false,
+		},
+		{
+			name:             "should reset only traffic for steadybit.com",
+			hostname:         []string{"steadybit.com"},
+			wantedReachable:  true,
+			wantedReachesUrl: false,
+		},
+		{
+			name:             "should reset only traffic for steadybit.com using CIDRs",
+			ip:               steadybitCIDRs,
+			wantedReachable:  true,
+			wantedReachesUrl: false,
+		},
+		{
+			name:             "should not reset traffic for non-matching ip",
+			ip:               []string{"8.8.0.0/16"},
+			wantedReachable:  true,
+			wantedReachesUrl: true,
+		},
+		{
+			name:             "should reset only port 80, 443 traffic on eth0",
+			port:             []string{"80", "443"},
+			interfaces:       []string{"eth0"},
+			wantedReachable:  false,
+			wantedReachesUrl: false,
+		},
+	}
+
+	for _, tt := range tests {
+		config := map[string]interface{}{
+			"duration":         30000,
+			"ip":               tt.ip,
+			"hostname":         tt.hostname,
+			"port":             tt.port,
+			"networkInterface": tt.interfaces,
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			nginx.AssertIsReachable(t, true)
+			nginx.AssertCanReach(t, "https://steadybit.com", true)
+
+			action, err := e.RunAction(exthost.BaseActionID+".network_tcp_reset", getTarget(m), config, defaultExecutionContext)
 			defer func() { _ = action.Cancel() }()
 			require.NoError(t, err)
 

--- a/exthost/action_network.go
+++ b/exthost/action_network.go
@@ -289,3 +289,15 @@ func toExcludes(restrictedEndpoints []action_kit_api.RestrictedEndpoint) ([]netw
 	}
 	return excludes, nil
 }
+
+func mapToExecutionContext(request action_kit_api.PrepareActionRequestBody) netfault.ExecutionContext {
+	eCtx := netfault.ExecutionContext{}
+	if request.ExecutionContext.ExperimentKey != nil {
+		eCtx.ExperimentKey = *request.ExecutionContext.ExperimentKey
+	}
+	if request.ExecutionContext.ExecutionId != nil {
+		eCtx.ExperimentExecutionId = *request.ExecutionContext.ExecutionId
+	}
+	eCtx.TargetExecutionId = request.ExecutionId.String()
+	return eCtx
+}

--- a/exthost/action_network_bandwidth.go
+++ b/exthost/action_network_bandwidth.go
@@ -90,9 +90,10 @@ func limitBandwidth(r ociruntime.OciRuntime) networkOptsProvider {
 		}
 
 		return &netfault.LimitBandwidthOpts{
-			Filter:     filter,
-			Bandwidth:  bandwidth,
-			Interfaces: interfaces,
+			Filter:           filter,
+			ExecutionContext: mapToExecutionContext(request),
+			Bandwidth:        bandwidth,
+			Interfaces:       interfaces,
 		}, messages, nil
 	}
 }

--- a/exthost/action_network_blackhole.go
+++ b/exthost/action_network_blackhole.go
@@ -70,7 +70,7 @@ func blackhole(r ociruntime.OciRuntime) networkOptsProvider {
 		}
 		messages = append(messages, netMessages...)
 
-		return &netfault.BlackholeOpts{Filter: filter}, messages, nil
+		return &netfault.BlackholeOpts{Filter: filter, ExecutionContext: mapToExecutionContext(request)}, messages, nil
 	}
 }
 

--- a/exthost/action_network_corrupt.go
+++ b/exthost/action_network_corrupt.go
@@ -91,9 +91,10 @@ func corruptPackages(r ociruntime.OciRuntime) networkOptsProvider {
 		}
 
 		return &netfault.CorruptPackagesOpts{
-			Filter:     filter,
-			Corruption: corruption,
-			Interfaces: interfaces,
+			Filter:           filter,
+			ExecutionContext: mapToExecutionContext(request),
+			Corruption:       corruption,
+			Interfaces:       interfaces,
 		}, messages, nil
 	}
 }

--- a/exthost/action_network_delay.go
+++ b/exthost/action_network_delay.go
@@ -118,11 +118,12 @@ func delay(r ociruntime.OciRuntime) networkOptsProvider {
 		}
 
 		return &netfault.DelayOpts{
-			Filter:     filter,
-			Delay:      delay,
-			Jitter:     jitter,
-			Interfaces: interfaces,
-			TcpPshOnly: extutil.ToBool(request.Config["tcpDataPacketsOnly"]),
+			Filter:           filter,
+			ExecutionContext: mapToExecutionContext(request),
+			Delay:            delay,
+			Jitter:           jitter,
+			Interfaces:       interfaces,
+			TcpPshOnly:       extutil.ToBool(request.Config["tcpDataPacketsOnly"]),
 		}, messages, nil
 	}
 }

--- a/exthost/action_network_dns.go
+++ b/exthost/action_network_dns.go
@@ -73,7 +73,8 @@ func blockDns() networkOptsProvider {
 		dnsPort := uint16(extutil.ToUInt(request.Config["dnsPort"]))
 
 		return &netfault.BlackholeOpts{
-			Filter: netfault.Filter{Include: network.NewNetWithPortRanges(network.NetAny, network.PortRange{From: dnsPort, To: dnsPort})},
+			Filter:           netfault.Filter{Include: network.NewNetWithPortRanges(network.NetAny, network.PortRange{From: dnsPort, To: dnsPort})},
+			ExecutionContext: mapToExecutionContext(request),
 		}, nil, nil
 	}
 }

--- a/exthost/action_network_tcp_reset.go
+++ b/exthost/action_network_tcp_reset.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 Steadybit GmbH
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
 
 package exthost
 
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_commons/network/netfault"
 	"github.com/steadybit/action-kit/go/action_kit_commons/ociruntime"
@@ -15,22 +16,22 @@ import (
 	"github.com/steadybit/extension-kit/extutil"
 )
 
-func NewNetworkPackageLossContainerAction(r ociruntime.OciRuntime) action_kit_sdk.Action[NetworkActionState] {
+func NewNetworkTcpResetAction(r ociruntime.OciRuntime) action_kit_sdk.Action[NetworkActionState] {
 	return &networkAction{
 		ociRuntime:   r,
-		optsProvider: packageLoss(r),
-		optsDecoder:  packageLossDecode,
-		description:  getNetworkPackageLossDescription(),
+		optsProvider: tcpReset(r),
+		optsDecoder:  tcpResetDecode,
+		description:  getNetworkTcpResetDescription(),
 	}
 }
 
-func getNetworkPackageLossDescription() action_kit_api.ActionDescription {
+func getNetworkTcpResetDescription() action_kit_api.ActionDescription {
 	return action_kit_api.ActionDescription{
-		Id:          fmt.Sprintf("%s.network_package_loss", BaseActionID),
-		Label:       "Drop Outgoing Traffic",
-		Description: "Cause packet loss for outgoing network traffic (egress).",
+		Id:          fmt.Sprintf("%s.network_tcp_reset", BaseActionID),
+		Label:       "Reset TCP Connection",
+		Description: "Injects TCP resets for matching connections (incoming and outgoing).",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:        extutil.Ptr(lossIcon),
+		Icon:        extutil.Ptr(blackHoleIcon),
 		TargetSelection: &action_kit_api.TargetSelection{
 			TargetType:         targetID,
 			SelectionTemplates: &targetSelectionTemplates,
@@ -41,15 +42,6 @@ func getNetworkPackageLossDescription() action_kit_api.ActionDescription {
 		TimeControl: action_kit_api.TimeControlExternal,
 		Parameters: append(
 			commonNetworkParameters,
-			action_kit_api.ActionParameter{
-				Name:         "percentage",
-				Label:        "Network Loss",
-				Description:  extutil.Ptr("How much of the traffic should be lost?"),
-				Type:         action_kit_api.ActionParameterTypePercentage,
-				DefaultValue: extutil.Ptr("70"),
-				Required:     extutil.Ptr(true),
-				Order:        extutil.Ptr(1),
-			},
 			action_kit_api.ActionParameter{
 				Name:        "networkInterface",
 				Label:       "Network Interface",
@@ -63,13 +55,12 @@ func getNetworkPackageLossDescription() action_kit_api.ActionDescription {
 	}
 }
 
-func packageLoss(r ociruntime.OciRuntime) networkOptsProvider {
+func tcpReset(r ociruntime.OciRuntime) networkOptsProvider {
 	return func(ctx context.Context, sidecar netfault.SidecarOpts, request action_kit_api.PrepareActionRequestBody) (netfault.Opts, action_kit_api.Messages, error) {
 		_, err := CheckTargetHostname(request.Target.Attributes)
 		if err != nil {
 			return nil, nil, err
 		}
-		loss := extutil.ToUInt(request.Config["percentage"])
 
 		filter, messages, err := mapToNetworkFilter(ctx, r, sidecar, request.Config, getRestrictedEndpoints(request))
 		if err != nil {
@@ -88,17 +79,17 @@ func packageLoss(r ociruntime.OciRuntime) networkOptsProvider {
 			return nil, nil, fmt.Errorf("no network interfaces specified")
 		}
 
-		return &netfault.PackageLossOpts{
+		return &netfault.TcpResetOpts{
 			Filter:           filter,
 			ExecutionContext: mapToExecutionContext(request),
-			Loss:             loss,
 			Interfaces:       interfaces,
+			InsertAtTop:      true,
 		}, messages, nil
 	}
 }
 
-func packageLossDecode(data json.RawMessage) (netfault.Opts, error) {
-	var opts netfault.PackageLossOpts
+func tcpResetDecode(data json.RawMessage) (netfault.Opts, error) {
+	var opts netfault.TcpResetOpts
 	err := json.Unmarshal(data, &opts)
 	return &opts, err
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.0
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_commons v1.5.16-0.20260330193757-b77567804c15
+	github.com/steadybit/action-kit/go/action_kit_commons v1.6.0
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,12 @@ github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdn
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
 github.com/steadybit/action-kit/go/action_kit_commons v1.5.16-0.20260330193757-b77567804c15 h1:Xm1HA+NiHi4D1P1fTH+IsL+LSHLQ0euRErGtI3cDQec=
 github.com/steadybit/action-kit/go/action_kit_commons v1.5.16-0.20260330193757-b77567804c15/go.mod h1:vt0xHssxPGeYI6Rq8Qu48YNYNJceupnmoeZiQu9Ra10=
+github.com/steadybit/action-kit/go/action_kit_commons v1.5.16-0.20260401142139-41c5be42de62 h1:9BxUd7DL4JdTJ82219F7szlyQjJCU+djWdtkpMjZufk=
+github.com/steadybit/action-kit/go/action_kit_commons v1.5.16-0.20260401142139-41c5be42de62/go.mod h1:vt0xHssxPGeYI6Rq8Qu48YNYNJceupnmoeZiQu9Ra10=
+github.com/steadybit/action-kit/go/action_kit_commons v1.5.16-0.20260401160115-17d12b76568c h1:g8jNmLhcmWQYyHUnGG6vtkGOJy8shkzLOPXiCiDmxaY=
+github.com/steadybit/action-kit/go/action_kit_commons v1.5.16-0.20260401160115-17d12b76568c/go.mod h1:vt0xHssxPGeYI6Rq8Qu48YNYNJceupnmoeZiQu9Ra10=
+github.com/steadybit/action-kit/go/action_kit_commons v1.6.0 h1:ZeQIIUbXi76PH/hwz224Xzkzo6mOW6zgMa9RzczsRdY=
+github.com/steadybit/action-kit/go/action_kit_commons v1.6.0/go.mod h1:vt0xHssxPGeYI6Rq8Qu48YNYNJceupnmoeZiQu9Ra10=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1 h1:c83hiU+RLWjqouWR9baiidmYcTtDTdRa5rkWKFvdbc8=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1/go.mod h1:DMMqDn4QNetxAoEXSpS7xF/vV+aD6YIDl/CgWOi5ii8=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 	action_kit_sdk.RegisterAction(exthost.NewStopProcessAction())
 	action_kit_sdk.RegisterAction(exthost.NewShutdownAction())
 	action_kit_sdk.RegisterAction(exthost.NewNetworkBlackholeContainerAction(r))
+	action_kit_sdk.RegisterAction(exthost.NewNetworkTcpResetAction(r))
 	action_kit_sdk.RegisterAction(exthost.NewNetworkLimitBandwidthContainerAction(r))
 	action_kit_sdk.RegisterAction(exthost.NewNetworkCorruptPackagesContainerAction(r))
 	action_kit_sdk.RegisterAction(exthost.NewNetworkDelayContainerAction(r))


### PR DESCRIPTION
## Summary
- Add new "Reset TCP Connection" network attack for Linux host targets
- Uses iptables REJECT rules with unique chain names per execution (from action-kit PR #408)
- Supports hostname/IP/port filters and interface targeting
- Adds `mapToExecutionContext` helper for `TcpResetOpts` chain name uniqueness

## Test plan
- [ ] Verify build passes in CI
- [ ] Manual test on a Linux host

Depends on action-kit PR steadybit/action-kit#408