### PR TITLE
chore: bump bundled binaries (nsmount v1.1.1, memfill v1.3.1)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,8 +15,8 @@ builds:
   - binary: extension-host
     env:
       - CGO_ENABLED=0
-      - MEMFILL_VERSION=v1.3.0
-      - NSMOUNT_VERSION=v1.1.0
+      - MEMFILL_VERSION=v1.3.1
+      - NSMOUNT_VERSION=v1.1.1
       - DNS_INJECT_VERSION=v0.1.4
     goos:
       - linux


### PR DESCRIPTION
## Summary

- Bump `NSMOUNT_VERSION` to **v1.1.1** — lowers the binary's GLIBC requirement from **2.30 → 2.28**, restoring compatibility with **RHEL 8 / Debian 10** for the Linux package (`.deb` / `.rpm`) installation. Previously the bundled nsmount would fail to load on those distros with `version GLIBC_2.30 not found`.
- Bump `MEMFILL_VERSION` to **v1.3.1** — dependency-only maintenance bump plus a new CI guard that ensures memfill stays under GLIBC 2.28 going forward.

Both upstream repos now run a CI step (`check-glibc.sh 2.28`) that fails the build if any released binary requires a glibc symbol above 2.28 — so this regression cannot silently come back.

## Test plan

- [ ] CI green
- [ ] Manually verified `nsmount.amd64` v1.1.1 runs inside a `rockylinux:8` container (glibc 2.28) without loader errors