### PR TITLE
docs: remove trivy-ignore bookkeeping from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v1.5.7
 
-- chore: add CVE-2026-48959 and CVE-2026-45447 to trivyignore
-- chore: add ignore to .trivyignore.yml
 - chore: update dns-inject v0.2.1
 - chore: update to go 1.26.4
 - feat: add weekly auto patch-release workflow


### PR DESCRIPTION
Removes auto-generated trivy-ignore bookkeeping bullets from the most recent CHANGELOG entry. The auto patch-release workflow emitted these before the trivy-ignore filter landed in extension-kit; they don't represent user-visible changes.