### PR TITLE
docs: mark SYS_RESOURCE capability as required

### DIFF
--- a/charts/steadybit-extension-host/Chart.yaml
+++ b/charts/steadybit-extension-host/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-host
 description: Steadybit host extension Helm chart for Kubernetes.
-version: 1.3.15
+version: 1.3.16
 appVersion: v1.5.8
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-host/values.yaml
+++ b/charts/steadybit-extension-host/values.yaml
@@ -153,7 +153,9 @@ containerSecurityContext:
       # SETPCAP, MKNOD is needed to support the crun OCI runtime. Better performance / needed on openshift clusters >= 4.18
       - SETPCAP
       - MKNOD
-      # SYS_RESOURCE is optional. If you remove it is more likely that the stress cpu/io/memory, fill memory attack will more likely be oomkilled
+      # SYS_RESOURCE is required: it is set as a file capability (cap_sys_resource) on the binary so the
+      # extension can lower its own oom_score_adj and stress cpu/io/memory and fill-memory attacks are not
+      # oom-killed. Removing it here will prevent the extension from starting (execve fails with EPERM).
       - SYS_RESOURCE
 # extraEnv -- Array with extra environment variables to add to the container
 # e.g:


### PR DESCRIPTION
Follow-up to #216. The extension now carries `cap_sys_resource` as a file capability (effective bit), so removing `SYS_RESOURCE` from the chart capabilities makes the binary fail to start (`execve` EPERM). Updates the values.yaml comment from "optional" to "required" to match.