### PR TITLE
docs: remove stray build: bullet from latest CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## v1.5.9
 
-- build: rename workflow_dispatch input labels for the GH UI
 - chore(deps): runc 1.4.3 and dns-inject to v0.2.2
 - feat: set oom_score_adj directly via extension-kit (drop root subprocess) (#216)
 - fix: switch back to use strict root qdisc checks


### PR DESCRIPTION
The auto-patch-release workflow added `- build: rename workflow_dispatch input labels for the GH UI` to the latest CHANGELOG entry. That bullet is a CI label rename with no runtime impact and shouldn't be user-facing.

A companion extension-kit PR adds `^build: ` to the default ignore regex so future runs skip such commits.