### PR TITLE
feat: thread qdisc snapshot through per-execution state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The pre-attack qdisc snapshot now lives in the action's per-execution state instead of an in-memory map in the extension process. An extension pod restart between Start and Stop no longer loses the snapshot, so Stop still restores the cloud-tuned root tree. Requires `action_kit_commons` v1.10.0.
 - One env var instead of two for network-attack root-qdisc handling. `STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE` is gone; the snapshot/restore path now auto-activates whenever `STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC=false`. Operators wanting the customer-friendly behaviour on managed-cloud nodes (run the attack and preserve the tuned root) set strict to false and get snapshot for free.
 
 ## v1.5.9

--- a/exthost/action_network.go
+++ b/exthost/action_network.go
@@ -39,6 +39,12 @@ type NetworkActionState struct {
 	ExecutionId uuid.UUID
 	NetworkOpts json.RawMessage
 	Sidecar     netfault.SidecarOpts
+	// QdiscSnapshot holds the pre-attack qdisc tree captured by netfault.Apply.
+	// It travels through the action_kit_sdk per-execution state so Stop can
+	// hand it back to netfault.Revert and restore the original (cloud-tuned)
+	// root after the attack tree is torn down. Empty when strict-mode is on,
+	// the attack doesn't touch a tc root, or the capture itself errored.
+	QdiscSnapshot netfault.QdiscSnapshot
 }
 
 // Make sure networkAction implements all required interfaces
@@ -141,7 +147,8 @@ func (a *networkAction) Start(ctx context.Context, state *NetworkActionState) (*
 		},
 	}}
 
-	err = netfault.Apply(ctx, runner(a.ociRuntime, state.Sidecar), opts)
+	snap, err := netfault.Apply(ctx, runner(a.ociRuntime, state.Sidecar), opts)
+	state.QdiscSnapshot = snap
 	if err != nil {
 		var toomany *netfault.ErrTooManyTcCommands
 		if errors.As(err, &toomany) {
@@ -163,7 +170,7 @@ func (a *networkAction) Stop(ctx context.Context, state *NetworkActionState) (*a
 		return nil, extension_kit.ToError("Failed to deserialize network settings.", err)
 	}
 
-	if err := netfault.Revert(ctx, runner(a.ociRuntime, state.Sidecar), opts); err != nil {
+	if err := netfault.Revert(ctx, runner(a.ociRuntime, state.Sidecar), opts, state.QdiscSnapshot); err != nil {
 		return nil, extension_kit.ToError("Failed to revert network settings.", err)
 	}
 

--- a/exthost/timetravel/ntp.go
+++ b/exthost/timetravel/ntp.go
@@ -18,8 +18,12 @@ func AdjustNtpTrafficRules(ctx context.Context, runner netfault.CommandRunner, a
 	}
 
 	if allowNtpTraffic {
-		return netfault.Revert(ctx, runner, opts)
+		// NTP blackhole uses iptables-only; netfault.Apply returns an empty
+		// QdiscSnapshot for opts that don't implement tcCommandProvider, so
+		// nothing meaningful is being discarded here.
+		return netfault.Revert(ctx, runner, opts, netfault.QdiscSnapshot{})
 	} else {
-		return netfault.Apply(ctx, runner, opts)
+		_, err := netfault.Apply(ctx, runner, opts)
+		return err
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/beevik/ntp v1.5.0
-	github.com/elastic/go-sysinfo v1.15.5
+	github.com/elastic/go-sysinfo v1.15.4
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mitchellh/go-ps v1.0.0
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_commons v1.9.0
+	github.com/steadybit/action-kit/go/action_kit_commons v1.10.0
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/beevik/ntp v1.5.0
-	github.com/elastic/go-sysinfo v1.15.4
+	github.com/elastic/go-sysinfo v1.15.5
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mitchellh/go-ps v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/elastic/go-sysinfo v1.15.5 h1:fCVUDmjHgljLUQCygherMnsRRJ9AkuAQIywTL7dEH28=
-github.com/elastic/go-sysinfo v1.15.5/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
+github.com/elastic/go-sysinfo v1.15.4 h1:A3zQcunCxik14MgXu39cXFXcIw2sFXZ0zL886eyiv1Q=
+github.com/elastic/go-sysinfo v1.15.4/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
 github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=
 github.com/elastic/go-windows v1.0.2/go.mod h1:bGcDpBzXgYSqM0Gx3DM4+UxFj300SZLixie9u9ixLM8=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -225,8 +225,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdnI3ttxX96nF2JAEQSx/zM8IQGwDo=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.9.0 h1:Vc7zdwr40VzcDTUKWqylqcNZVxZfidTU2/UikFXKvbQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.9.0/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
+github.com/steadybit/action-kit/go/action_kit_commons v1.10.0 h1:KwylN8dtI7chs0gB953jpj5k0zVTrXqmsxChsCzL1Po=
+github.com/steadybit/action-kit/go/action_kit_commons v1.10.0/go.mod h1:Dg5Q26LfchJnGKrMubHnVXzxaJL3ykx0naNbH05lL+Q=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1 h1:c83hiU+RLWjqouWR9baiidmYcTtDTdRa5rkWKFvdbc8=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1/go.mod h1:DMMqDn4QNetxAoEXSpS7xF/vV+aD6YIDl/CgWOi5ii8=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/elastic/go-sysinfo v1.15.4 h1:A3zQcunCxik14MgXu39cXFXcIw2sFXZ0zL886eyiv1Q=
-github.com/elastic/go-sysinfo v1.15.4/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
+github.com/elastic/go-sysinfo v1.15.5 h1:fCVUDmjHgljLUQCygherMnsRRJ9AkuAQIywTL7dEH28=
+github.com/elastic/go-sysinfo v1.15.5/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
 github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=
 github.com/elastic/go-windows v1.0.2/go.mod h1:bGcDpBzXgYSqM0Gx3DM4+UxFj300SZLixie9u9ixLM8=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=


### PR DESCRIPTION
## Summary

- Bump `action_kit_commons` to `v1.10.0`, which moves the netfault snapshot out of a process-local map and into the value `netfault.Apply` returns.
- `NetworkActionState` gains a `QdiscSnapshot` field. `Start` stashes what `Apply` returns; `Stop` hands it back to `Revert`. The action_kit_sdk serializes state as JSON so the snapshot rides through a pod restart cleanly.
- `timetravel.AdjustNtpTrafficRules` discards the (empty) snapshot — `BlackholeOpts` is iptables-only and never touches a tc root, so capture is a no-op there.

## Why

With the old in-memory store, restarting the extension pod between `Start` and `Stop` lost the snapshot and `Stop` degraded to the kernel-default-restore behaviour — exactly the regression v1.5.8 was added to fix. With the snapshot in per-execution state, the Steadybit platform holds it for the duration of the experiment and `Stop` restores the original tree regardless of the extension pod's lifecycle.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./exthost ./exthost/timetravel -short` passes
- [ ] CI green