### PR TITLE
feat: add exclude IPs/CIDRs parameter to network attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: new `Exclude IPs/CIDRs` parameter (`excludeIp`) on the delay attack — delay all traffic except the given IPs/CIDRs. Excludes take precedence over the include restrictions (hostnames, IPs/CIDRs, ports).
+
 ## v1.5.10
 
 - feat: opt-in qdisc snapshot/restore for network attacks. Set `STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC=false` to make Apply capture the root qdisc tree (qdiscs + filters) of every target interface and Revert replay it after the attack's `tc del`. Preserves cloud-tuned root qdiscs (e.g. GKE's `mq + fq` with `buckets=32768 horizon=2s`) that would otherwise revert to kernel defaults after `tc qdisc del root` and leave the host network degraded until reboot. Off by default; Linux only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: new `Exclude IPs/CIDRs` parameter (`excludeIp`) on all network attacks sharing the hostname/IP/port filters (delay, loss, corruption, bandwidth, blackhole, TCP reset) — affect all traffic except the given IPs/CIDRs. Excludes always take precedence over the include restrictions. The existing filter parameters are relabeled to `Include Hostnames`, `Include IPs/CIDRs` and `Include Ports` to make the distinction explicit.
+- feat: new `Exclude Hostnames` (`excludeHostname`) and `Exclude IPs/CIDRs` (`excludeIp`) parameters on all network attacks sharing the hostname/IP/port filters (delay, loss, corruption, bandwidth, blackhole, TCP reset) — affect all traffic except the given hosts or IPs/CIDRs. Excludes always take precedence over the include restrictions. The existing filter parameters are relabeled to `Include Hostnames`, `Include IPs/CIDRs` and `Include Ports` to make the distinction explicit.
 
 ## v1.5.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: new `Exclude IPs/CIDRs` parameter (`excludeIp`) on the delay attack — delay all traffic except the given IPs/CIDRs. Excludes take precedence over the include restrictions (hostnames, IPs/CIDRs, ports).
+- feat: new `Exclude IPs/CIDRs` parameter (`excludeIp`) on all network attacks sharing the hostname/IP/port filters (delay, loss, corruption, bandwidth, blackhole, TCP reset) — affect all traffic except the given IPs/CIDRs. Excludes always take precedence over the include restrictions. The existing filter parameters are relabeled to `Include Hostnames`, `Include IPs/CIDRs` and `Include Ports` to make the distinction explicit.
 
 ## v1.5.10
 

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -605,6 +605,7 @@ func testNetworkDelay(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 		ip                  []string
 		hostname            []string
 		port                []string
+		excludeIp           []string
 		interfaces          []string
 		restrictedEndpoints []action_kit_api.RestrictedEndpoint
 		wantedDelay         bool
@@ -638,6 +639,12 @@ func testNetworkDelay(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 			restrictedEndpoints: generateRestrictedEndpoints(1500),
 			wantedDelay:         true,
 		},
+		{
+			name:                "should not delay traffic for excluded cidr",
+			excludeIp:           []string{fmt.Sprintf("%s/32", netperf.ServerIp)},
+			restrictedEndpoints: generateRestrictedEndpoints(1500),
+			wantedDelay:         false,
+		},
 	}
 
 	unaffectedLatency, err := netperf.MeasureLatency()
@@ -652,6 +659,7 @@ func testNetworkDelay(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 			"ip":                 tt.ip,
 			"hostname":           tt.hostname,
 			"port":               tt.port,
+			"excludeIp":          tt.excludeIp,
 			"networkInterface":   tt.interfaces,
 		}
 

--- a/exthost/action_network.go
+++ b/exthost/action_network.go
@@ -89,13 +89,22 @@ var commonNetworkParameters = []action_kit_api.ActionParameter{
 		Order:        new(103),
 	},
 	{
+		Name:        "excludeHostname",
+		Label:       "Exclude Hostnames",
+		Description: new("Exclude traffic to/from these hosts from being affected. Excludes always take precedence over the include restrictions above (hostnames, IPs/CIDRs, ports)."),
+		Type:        action_kit_api.ActionParameterTypeStringArray,
+		Required:    new(false),
+		Advanced:    new(true),
+		Order:       new(104),
+	},
+	{
 		Name:        "excludeIp",
 		Label:       "Exclude IPs/CIDRs",
 		Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being affected. Excludes always take precedence over the include restrictions above (hostnames, IPs/CIDRs, ports), e.g. affect all traffic except 10.0.0.0/8."),
 		Type:        action_kit_api.ActionParameterTypeStringArray,
 		Required:    new(false),
 		Advanced:    new(true),
-		Order:       new(104),
+		Order:       new(105),
 	},
 }
 
@@ -259,7 +268,10 @@ func mapToNetworkFilter(ctx context.Context, r ociruntime.OciRuntime, sidecar ne
 		return netfault.Filter{}, nil, err
 	}
 
-	excludeCidrs, unresolvedExcludes := network.ParseCIDRs(extutil.ToStringArray(actionConfig["excludeIp"]))
+	excludeCidrs, unresolvedExcludes := network.ParseCIDRs(append(
+		extutil.ToStringArray(actionConfig["excludeIp"]),
+		extutil.ToStringArray(actionConfig["excludeHostname"])...,
+	))
 	resolvedExcludes, err := dnsResolver(r, sidecar).Resolve(ctx, unresolvedExcludes...)
 	if err != nil {
 		return netfault.Filter{}, nil, err

--- a/exthost/action_network.go
+++ b/exthost/action_network.go
@@ -63,7 +63,7 @@ var commonNetworkParameters = []action_kit_api.ActionParameter{
 	},
 	{
 		Name:         "hostname",
-		Label:        "Hostnames",
+		Label:        "Include Hostnames",
 		Description:  new("Restrict to/from which hosts the traffic is affected."),
 		Type:         action_kit_api.ActionParameterTypeStringArray,
 		DefaultValue: new(""),
@@ -72,7 +72,7 @@ var commonNetworkParameters = []action_kit_api.ActionParameter{
 	},
 	{
 		Name:         "ip",
-		Label:        "IPs/CIDRs",
+		Label:        "Include IPs/CIDRs",
 		Description:  new("Restrict to/from which IP addresses or blocks the traffic is affected."),
 		Type:         action_kit_api.ActionParameterTypeStringArray,
 		DefaultValue: new(""),
@@ -81,12 +81,21 @@ var commonNetworkParameters = []action_kit_api.ActionParameter{
 	},
 	{
 		Name:         "port",
-		Label:        "Ports",
+		Label:        "Include Ports",
 		Description:  new("Restrict to/from which ports the traffic is affected."),
 		Type:         action_kit_api.ActionParameterTypeStringArray,
 		DefaultValue: new(""),
 		Advanced:     new(true),
 		Order:        new(103),
+	},
+	{
+		Name:        "excludeIp",
+		Label:       "Exclude IPs/CIDRs",
+		Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being affected. Excludes always take precedence over the include restrictions above (hostnames, IPs/CIDRs, ports), e.g. affect all traffic except 10.0.0.0/8."),
+		Type:        action_kit_api.ActionParameterTypeStringArray,
+		Required:    new(false),
+		Advanced:    new(true),
+		Order:       new(104),
 	},
 }
 

--- a/exthost/action_network.go
+++ b/exthost/action_network.go
@@ -239,8 +239,8 @@ func mapToNetworkFilter(ctx context.Context, r ociruntime.OciRuntime, sidecar ne
 	}
 
 	includes := network.NewNetWithPortRanges(includeCidrs, portRanges...)
-	for _, i := range includes {
-		i.Comment = "parameters"
+	for i := range includes {
+		includes[i].Comment = "parameters"
 	}
 
 	slices.SortFunc(includes, network.NetWithPortRange.Compare)
@@ -249,6 +249,19 @@ func mapToNetworkFilter(ctx context.Context, r ociruntime.OciRuntime, sidecar ne
 	if err != nil {
 		return netfault.Filter{}, nil, err
 	}
+
+	excludeCidrs, unresolvedExcludes := network.ParseCIDRs(extutil.ToStringArray(actionConfig["excludeIp"]))
+	resolvedExcludes, err := dnsResolver(r, sidecar).Resolve(ctx, unresolvedExcludes...)
+	if err != nil {
+		return netfault.Filter{}, nil, err
+	}
+	excludeCidrs = append(excludeCidrs, network.IpsToNets(resolvedExcludes)...)
+
+	userExcludes := network.NewNetWithPortRanges(excludeCidrs, network.PortRangeAny)
+	for i := range userExcludes {
+		userExcludes[i].Comment = "parameters"
+	}
+	excludes = append(excludes, userExcludes...)
 
 	excludes = append(excludes, network.ComputeExcludesForOwnIpAndPorts(config.Config.Port, config.Config.HealthPort)...)
 

--- a/exthost/action_network_bandwidth.go
+++ b/exthost/action_network_bandwidth.go
@@ -58,7 +58,7 @@ func getNetworkLimitBandwidthDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(105),
+				Order:       new(106),
 			},
 		),
 	}

--- a/exthost/action_network_bandwidth.go
+++ b/exthost/action_network_bandwidth.go
@@ -58,7 +58,7 @@ func getNetworkLimitBandwidthDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(104),
+				Order:       new(105),
 			},
 		),
 	}

--- a/exthost/action_network_corrupt.go
+++ b/exthost/action_network_corrupt.go
@@ -59,7 +59,7 @@ func getNetworkCorruptPackagesDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(104),
+				Order:       new(105),
 			},
 		),
 	}

--- a/exthost/action_network_corrupt.go
+++ b/exthost/action_network_corrupt.go
@@ -59,7 +59,7 @@ func getNetworkCorruptPackagesDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(105),
+				Order:       new(106),
 			},
 		),
 	}

--- a/exthost/action_network_delay.go
+++ b/exthost/action_network_delay.go
@@ -70,16 +70,7 @@ func getNetworkDelayDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(104),
-			},
-			action_kit_api.ActionParameter{
-				Name:        "excludeIp",
-				Label:       "Exclude IPs/CIDRs",
-				Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being delayed. Excludes always take precedence over the Hostnames, IPs/CIDRs and Ports restrictions, e.g. delay all traffic except 10.0.0.0/8."),
-				Type:        action_kit_api.ActionParameterTypeStringArray,
-				Required:    new(false),
-				Advanced:    new(true),
-				Order:       new(106),
+				Order:       new(105),
 			},
 			action_kit_api.ActionParameter{
 				Name:         "tcpDataPacketsOnly",
@@ -89,7 +80,7 @@ func getNetworkDelayDescription() action_kit_api.ActionDescription {
 				DefaultValue: new("false"),
 				Required:     new(true),
 				Advanced:     new(true),
-				Order:        new(105),
+				Order:        new(106),
 			},
 		),
 	}

--- a/exthost/action_network_delay.go
+++ b/exthost/action_network_delay.go
@@ -75,7 +75,7 @@ func getNetworkDelayDescription() action_kit_api.ActionDescription {
 			action_kit_api.ActionParameter{
 				Name:        "excludeIp",
 				Label:       "Exclude IPs/CIDRs",
-				Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being delayed. Takes precedence over the restrictions above, e.g. delay all traffic except 10.0.0.0/8."),
+				Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being delayed. Excludes always take precedence over the Hostnames, IPs/CIDRs and Ports restrictions, e.g. delay all traffic except 10.0.0.0/8."),
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),

--- a/exthost/action_network_delay.go
+++ b/exthost/action_network_delay.go
@@ -70,7 +70,7 @@ func getNetworkDelayDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(105),
+				Order:       new(106),
 			},
 			action_kit_api.ActionParameter{
 				Name:         "tcpDataPacketsOnly",
@@ -80,7 +80,7 @@ func getNetworkDelayDescription() action_kit_api.ActionDescription {
 				DefaultValue: new("false"),
 				Required:     new(true),
 				Advanced:     new(true),
-				Order:        new(106),
+				Order:        new(107),
 			},
 		),
 	}

--- a/exthost/action_network_delay.go
+++ b/exthost/action_network_delay.go
@@ -73,6 +73,15 @@ func getNetworkDelayDescription() action_kit_api.ActionDescription {
 				Order:       new(104),
 			},
 			action_kit_api.ActionParameter{
+				Name:        "excludeIp",
+				Label:       "Exclude IPs/CIDRs",
+				Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being delayed. Takes precedence over the restrictions above, e.g. delay all traffic except 10.0.0.0/8."),
+				Type:        action_kit_api.ActionParameterTypeStringArray,
+				Required:    new(false),
+				Advanced:    new(true),
+				Order:       new(106),
+			},
+			action_kit_api.ActionParameter{
 				Name:         "tcpDataPacketsOnly",
 				Label:        "TCP Data Packets Only [beta]",
 				Description:  new("Delay only TCP data packets (PSH flag heuristic). UDP is not delayed. When you observe the actual delay being a multiple of the configured delay, you might choose this option to avoid delaying the TCP handshake."),

--- a/exthost/action_network_loss.go
+++ b/exthost/action_network_loss.go
@@ -57,7 +57,7 @@ func getNetworkPackageLossDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(105),
+				Order:       new(106),
 			},
 		),
 	}

--- a/exthost/action_network_loss.go
+++ b/exthost/action_network_loss.go
@@ -57,7 +57,7 @@ func getNetworkPackageLossDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(104),
+				Order:       new(105),
 			},
 		),
 	}

--- a/exthost/action_network_tcp_reset.go
+++ b/exthost/action_network_tcp_reset.go
@@ -49,7 +49,7 @@ func getNetworkTcpResetDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(105),
+				Order:       new(106),
 			},
 		),
 	}

--- a/exthost/action_network_tcp_reset.go
+++ b/exthost/action_network_tcp_reset.go
@@ -49,7 +49,7 @@ func getNetworkTcpResetDescription() action_kit_api.ActionDescription {
 				Type:        action_kit_api.ActionParameterTypeStringArray,
 				Required:    new(false),
 				Advanced:    new(true),
-				Order:       new(104),
+				Order:       new(105),
 			},
 		),
 	}

--- a/exthost/action_network_test.go
+++ b/exthost/action_network_test.go
@@ -42,6 +42,14 @@ func TestMapToNetworkFilterExcludeIp(t *testing.T) {
 			},
 			wantExcluded: []string{"10.1.0.0/16 # parameters"},
 		},
+		{
+			name: "excludeHostname entries are excluded together with excludeIp",
+			actionConfig: map[string]any{
+				"excludeIp":       []interface{}{"10.0.0.0/8"},
+				"excludeHostname": []interface{}{"192.168.1.1"},
+			},
+			wantExcluded: []string{"10.0.0.0/8 # parameters", "192.168.1.1/32 # parameters"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/exthost/action_network_test.go
+++ b/exthost/action_network_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package exthost
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steadybit/action-kit/go/action_kit_commons/network"
+	"github.com/steadybit/action-kit/go/action_kit_commons/network/netfault"
+	"github.com/steadybit/extension-host/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapToNetworkFilterExcludeIp(t *testing.T) {
+	config.Config.DisableRunc = true
+
+	tests := []struct {
+		name         string
+		actionConfig map[string]any
+		wantExcluded []string
+	}{
+		{
+			name:         "no excludeIp yields no parameter excludes",
+			actionConfig: map[string]any{},
+			wantExcluded: nil,
+		},
+		{
+			name: "excludeIp CIDRs and IPs are excluded on all ports",
+			actionConfig: map[string]any{
+				"excludeIp": []interface{}{"10.0.0.0/8", "192.168.1.1"},
+			},
+			wantExcluded: []string{"10.0.0.0/8 # parameters", "192.168.1.1/32 # parameters"},
+		},
+		{
+			name: "excludeIp composes with include restrictions",
+			actionConfig: map[string]any{
+				"ip":        []interface{}{"10.0.0.0/8"},
+				"excludeIp": []interface{}{"10.1.0.0/16"},
+			},
+			wantExcluded: []string{"10.1.0.0/16 # parameters"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, _, err := mapToNetworkFilter(context.Background(), nil, netfault.SidecarOpts{}, tt.actionConfig, nil)
+			require.NoError(t, err)
+
+			var parameterExcludes []string
+			for _, e := range filter.Exclude {
+				if e.Comment == "parameters" {
+					assert.Equal(t, network.PortRangeAny, e.PortRange)
+					parameterExcludes = append(parameterExcludes, e.String())
+				}
+			}
+			assert.Equal(t, tt.wantExcluded, parameterExcludes)
+
+			for _, i := range filter.Include {
+				assert.Equal(t, "parameters", i.Comment)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a new advanced parameter **Exclude IPs/CIDRs** (`excludeIp`) to all network attacks sharing the hostname/IP/port filters (delay, loss, corruption, bandwidth, blackhole, TCP reset), making it possible to affect all traffic *except* some CIDRs (e.g. leave the include filters empty and exclude `10.0.0.0/8`). Hostnames are accepted too and resolved via the same DNS logic as the include filters.

The existing filter parameters are relabeled to **Include Hostnames**, **Include IPs/CIDRs** and **Include Ports** to make explicit that they are includes as opposed to the new exclude parameter.

## How

- `mapToNetworkFilter` (shared by all network attacks) parses `excludeIp`, resolves non-CIDR entries via DNS, and appends the resulting nets on all ports to the filter's exclude list, next to the existing agent/extension protection excludes.
- The parameter lives in `commonNetworkParameters` (advanced, order 104, right after the include filters); the per-action advanced parameters were bumped by one to keep the filter block together in the UI.

Excludes always take precedence over includes in `netfault`, by construction:
- tc path: exclude filters are emitted first (lower `prio`) and steer traffic to the unaffected band `1:1`; includes go to the attack band `1:3`.
- `tcpDataPacketsOnly` iptables path: excludes are written as `-j RETURN` rules before the include `-j MARK` rules.

It is rule ordering, not longest-prefix matching, so an exclude inside a broader include CIDR behaves correctly. When excludes get condensed (too many tc commands) they are only ever broadened, never dropped.

## Tests

- New unit tests for `mapToNetworkFilter` covering default (no excludes), exclude CIDRs/IPs on all ports, and exclude composing with an include restriction.
- New e2e delay test case "should not delay traffic for excluded cidr".

## Drive-by fix

The loop setting `Comment = "parameters"` on the include filters assigned to a range copy, so the comments never appeared in log output. Fixed to assign via index.

Kept in sync with steadybit/extension-container#471.