### PR TITLE
fix: prevent stop-process crash when a matched process exits early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: the `stop-process` attack no longer crashes the extension with a nil pointer dereference when a matched process exits before it is stopped (`ps.FindProcess` returns `nil, nil` for a vanished PID on Linux).
+
 ## v1.6.1
 
 - build(deps): bump golang.org/x/sync from 0.21.0 to 0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - fix: the `stop-process` attack no longer crashes the extension with a nil pointer dereference when a matched process exits before it is stopped (`ps.FindProcess` returns `nil, nil` for a vanished PID on Linux).
+- fix: network attacks no longer crash the extension during Prepare when the request omits `executionContext` (nil pointer dereference in `mapToExecutionContext`).
+- fix: `fill-disk` and `fill-memory` no longer crash the extension during Prepare when a config parameter is missing or has an unexpected type; config values are now read via the tolerant `extutil` helpers.
 
 ## v1.6.1
 

--- a/exthost/action_fill_disk.go
+++ b/exthost/action_fill_disk.go
@@ -155,8 +155,8 @@ func fillDiskOpts(request action_kit_api.PrepareActionRequestBody) (diskfill.Opt
 		TempPath: extutil.ToString(request.Config["path"]),
 	}
 
-	opts.BlockSize = int(request.Config["blocksize"].(float64))
-	opts.Size = int(request.Config["size"].(float64))
+	opts.BlockSize = extutil.ToInt(request.Config["blocksize"])
+	opts.Size = extutil.ToInt(request.Config["size"])
 	switch request.Config["mode"] {
 	case string(diskfill.Percentage):
 		opts.Mode = diskfill.Percentage

--- a/exthost/action_fill_mem.go
+++ b/exthost/action_fill_mem.go
@@ -135,11 +135,11 @@ func (a *fillMemoryAction) Describe() action_kit_api.ActionDescription {
 }
 
 func fillMemoryOpts(request action_kit_api.PrepareActionRequestBody) (memfill.Opts, error) {
-	mode := memfill.Mode(request.Config["mode"].(string))
+	mode := memfill.Mode(extutil.ToString(request.Config["mode"]))
 	opts := memfill.Opts{
 		Size:         extutil.ToInt(request.Config["size"]),
 		Mode:         mode,
-		Unit:         memfill.Unit(request.Config["unit"].(string)),
+		Unit:         memfill.Unit(extutil.ToString(request.Config["unit"])),
 		Duration:     time.Duration(extutil.ToInt64(request.Config["duration"])) * time.Millisecond,
 		IgnoreCgroup: true,
 		// Keep the host alive under the fill: always leave a reserve free (so the kubelet survives),

--- a/exthost/action_network.go
+++ b/exthost/action_network.go
@@ -337,6 +337,9 @@ func toExcludes(restrictedEndpoints []action_kit_api.RestrictedEndpoint) ([]netw
 
 func mapToExecutionContext(request action_kit_api.PrepareActionRequestBody) netfault.ExecutionContext {
 	eCtx := netfault.ExecutionContext{}
+	if request.ExecutionContext == nil {
+		return eCtx
+	}
 	if request.ExecutionContext.ExperimentKey != nil {
 		eCtx.ExperimentKey = *request.ExecutionContext.ExperimentKey
 	}

--- a/exthost/action_network_test.go
+++ b/exthost/action_network_test.go
@@ -7,12 +7,21 @@ import (
 	"context"
 	"testing"
 
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_commons/network"
 	"github.com/steadybit/action-kit/go/action_kit_commons/network/netfault"
 	"github.com/steadybit/extension-host/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMapToExecutionContextWithoutExecutionContext(t *testing.T) {
+	assert.NotPanics(t, func() {
+		eCtx := mapToExecutionContext(action_kit_api.PrepareActionRequestBody{})
+		assert.Empty(t, eCtx.ExperimentKey)
+		assert.Empty(t, eCtx.ExperimentExecutionId)
+	})
+}
 
 func TestMapToNetworkFilterExcludeIp(t *testing.T) {
 	config.Config.DisableRunc = true

--- a/exthost/process/process_util.go
+++ b/exthost/process/process_util.go
@@ -22,11 +22,11 @@ func StopProcesses(pid []int, force bool) error {
 
 	var errs error
 	for _, p := range pid {
-		if process, err := ps.FindProcess(p); err == nil {
-			log.Info().Int("pid", p).Str("name", process.Executable()).Msg("Stopping process")
-		} else {
+		process, err := ps.FindProcess(p)
+		if err != nil || process == nil {
 			continue
 		}
+		log.Info().Int("pid", p).Str("name", process.Executable()).Msg("Stopping process")
 
 		if err := stopProcessUnix(p, force); err != nil {
 			errs = errors.Join(errs, err)

--- a/exthost/process/process_util_test.go
+++ b/exthost/process/process_util_test.go
@@ -18,9 +18,13 @@ func TestStopProcesses(t *testing.T) {
 }
 
 func TestStopProcessesSkipsVanishedPid(t *testing.T) {
-	nonExistentPid := 4194303
+	command := exec.Command("true")
+	assert.NoError(t, command.Start())
+	vanishedPid := command.Process.Pid
+	assert.NoError(t, command.Wait())
+
 	assert.NotPanics(t, func() {
-		err := StopProcesses([]int{nonExistentPid}, true)
+		err := StopProcesses([]int{vanishedPid}, true)
 		assert.NoError(t, err)
 	})
 }

--- a/exthost/process/process_util_test.go
+++ b/exthost/process/process_util_test.go
@@ -16,3 +16,11 @@ func TestStopProcesses(t *testing.T) {
 	err = StopProcesses(ids, true)
 	assert.NoError(t, err)
 }
+
+func TestStopProcessesSkipsVanishedPid(t *testing.T) {
+	nonExistentPid := 4194303
+	assert.NotPanics(t, func() {
+		err := StopProcesses([]int{nonExistentPid}, true)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Hardens the host extension's Prepare/attack paths against inputs that trigger a nil-pointer dereference and crash the whole extension. Started from a customer crash report on `stop-process`; a follow-up sweep found two more instances of the same class.

## 1. stop-process — vanished PID (customer report)

```
INF ... status=200 url=/com.steadybit.extension_host.stop-process/start
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x8555d6]
```

The stop-process goroutine loops, repeatedly stopping every PID matching the filter. `ps.FindProcess(p)` returns `(nil, nil)` on Linux when `/proc/<pid>` no longer exists (go-ps `findProcess` returns `nil, nil` on `os.IsNotExist`). The code only guarded on `err == nil`, then called `process.Executable()` on the nil process. A process exiting between discovery and stopping — including one already killed by the previous loop iteration — crashed the extension.

**Fix:** skip vanished PIDs (`err != nil || process == nil`).

## 2. Network attacks — missing executionContext

`mapToExecutionContext` (`action_network.go`) dereferenced `request.ExecutionContext.ExperimentKey` without checking `request.ExecutionContext != nil`. That field is `*ExecutionContext` with `omitempty`, so it is nil when a Prepare request omits `executionContext` (ad-hoc / direct API runs). A sibling helper (`common.go` `getRestrictedEndpoints`) already guarded the same pointer. Affects the Prepare path of all seven network attacks (blackhole, block-dns, delay, loss, corrupt, bandwidth, tcp-reset).

**Fix:** return early when `request.ExecutionContext == nil`.

## 3. fill-disk / fill-memory — raw config type assertions

`action_fill_disk.go` and `action_fill_mem.go` read config values via raw `.(float64)` / `.(string)` assertions on the JSON `map[string]any`, which panic on a missing or wrong-typed parameter. Neighbouring fields already use the tolerant `extutil.To*` helpers.

**Fix:** read `blocksize`, `size`, `mode`, `unit` via `extutil.ToInt` / `extutil.ToString`.

## Tests

- `TestStopProcessesSkipsVanishedPid` — no panic / no error for a non-existent PID.
- `TestMapToExecutionContextWithoutExecutionContext` — no panic when `executionContext` is absent.

Build, vet, and the new tests pass.