### PR TITLE
build: run CI on the ARM 4-core runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
       go_version: '^1.26.5'
-      runs_on: steadybit_runner_ubuntu_latest_4cores_16GB
+      runs_on: steadybit_runner_ubuntu_latest_4cores_16GB_ARM
       run_make_prepare_audit: true
       build_linux_packages: true
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}


### PR DESCRIPTION
## What
Flip the CI `runs_on` from the x86 custom runner `steadybit_runner_ubuntu_latest_4cores_16GB` to the ARM one `steadybit_runner_ubuntu_latest_4cores_16GB_ARM` (~33% cheaper per minute).

## Prerequisite (done)
Depended on steadybit/extension-kit#164 (install Snyk via npm) — **now merged**. That made the reusable `audit` job ARM-capable; before it, the job died at init pulling the amd64-only `snyk/snyk:golang` image. CI here confirms the `audit` job now clears init on ARM.

## What CI validates
host's network-chaos e2e tests (`tc qdisc`/netem — `network_package_loss`, `network_package_corruption`) run on the ARM *larger* runner. These pass on the x86 larger runner and fail on the free `ubuntu-latest`; the ARM larger runner was the open question. Auto-merge gates on these checks, so this only merges if they pass on ARM — if netem isn't supported there, the checks stay red and it won't merge.

## Why
host is the only extension still on a paid custom runner; ARM is ~33% cheaper (~$14/yr), and this proves the reusable workflow works end-to-end on ARM.