### PR TITLE
fix: network attacks now affect portless protocols (e.g. ICMP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.7.1
+
+- fix: network attacks now also affect protocols without ports (e.g. ICMP) when no port is specified. Previously an unset port implied the port range 1-65534, so only port-bearing protocols (TCP/UDP/SCTP) were blocked and ICMP traffic slipped through the blackhole attack.
+
 ## v1.7.0
 
 - ci: skip build on .trivyignore.yml-only changes [skip ci]

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -441,6 +441,8 @@ func testNetworkBlackhole(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 	require.NoError(t, err, "failed to create pod")
 	defer func() { _ = nginx.Delete() }()
 
+	gateway := nginxDefaultGateway(t, &nginx)
+
 	tests := []struct {
 		name             string
 		ip               []string
@@ -448,35 +450,41 @@ func testNetworkBlackhole(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 		port             []string
 		wantedReachable  bool
 		wantedReachesUrl bool
+		wantedCanPing    bool
 	}{
 		{
 			name:             "should blackhole all traffic",
 			wantedReachable:  false,
 			wantedReachesUrl: false,
+			wantedCanPing:    false,
 		},
 		{
 			name:             "should blackhole only port 8080 traffic",
 			port:             []string{"8080"},
 			wantedReachable:  true,
 			wantedReachesUrl: true,
+			wantedCanPing:    true,
 		},
 		{
 			name:             "should blackhole only port 80, 443 traffic",
 			port:             []string{"80", "443"},
 			wantedReachable:  false,
 			wantedReachesUrl: false,
+			wantedCanPing:    true,
 		},
 		{
 			name:             "should blackhole only traffic for steadybit.com",
 			hostname:         []string{"steadybit.com"},
 			wantedReachable:  true,
 			wantedReachesUrl: false,
+			wantedCanPing:    true,
 		},
 		{
 			name:             "should blackhole only traffic for steadybit.com",
 			ip:               steadybitCIDRs,
 			wantedReachable:  true,
 			wantedReachesUrl: false,
+			wantedCanPing:    true,
 		},
 	}
 
@@ -491,6 +499,7 @@ func testNetworkBlackhole(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 		t.Run(tt.name, func(t *testing.T) {
 			nginx.AssertIsReachable(t, true)
 			nginx.AssertCanReach(t, "https://steadybit.com", true)
+			assertNginxCanPing(t, &nginx, gateway, true)
 
 			action, err := e.RunAction(exthost.BaseActionID+".network_blackhole", getTarget(m), config, defaultExecutionContext)
 			defer func() { _ = action.Cancel() }()
@@ -498,13 +507,50 @@ func testNetworkBlackhole(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 
 			nginx.AssertIsReachable(t, tt.wantedReachable)
 			nginx.AssertCanReach(t, "https://steadybit.com", tt.wantedReachesUrl)
+			assertNginxCanPing(t, &nginx, gateway, tt.wantedCanPing)
 
 			require.NoError(t, action.Cancel())
 			nginx.AssertIsReachable(t, true)
 			nginx.AssertCanReach(t, "https://steadybit.com", true)
+			assertNginxCanPing(t, &nginx, gateway, true)
 		})
 	}
 	requireAllSidecarsCleanedUp(t, m, e)
+}
+
+// nginxDefaultGateway returns the nginx pod's default-route gateway, used as an
+// in-cluster ICMP target. It reliably answers ping when reachable and is still
+// covered by a blackhole spanning 0.0.0.0/0, unlike a public host whose ICMP
+// egress is unreliable on CI networks.
+func nginxDefaultGateway(t *testing.T, nginx *e2e.Nginx) string {
+	t.Helper()
+	out, err := nginx.Minikube.PodExec(nginx.Pod, "nginx", "ip", "-4", "route", "show", "default")
+	require.NoError(t, err)
+	fields := strings.Fields(out)
+	for i, f := range fields {
+		if f == "via" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	require.Failf(t, "default gateway not found", "could not parse default gateway from %q", out)
+	return ""
+}
+
+// assertNginxCanPing runs a single ICMP echo from the nginx container to host
+// and asserts whether it succeeds. It exercises a protocol without ports, which
+// a port-scoped blackhole must leave untouched while a portless one must block.
+func assertNginxCanPing(t *testing.T, nginx *e2e.Nginx, host string, expected bool) {
+	t.Helper()
+	e2e.Retry(t, 8, 500*time.Millisecond, func(r *e2e.R) {
+		out, err := nginx.Minikube.PodExec(nginx.Pod, "nginx", "ping", "-c", "1", "-W", "2", host)
+		if expected && err != nil {
+			r.Failed = true
+			_, _ = fmt.Fprintf(r.Log, "expected %s to be pingable from nginx, but was not: %s: %s", host, err, out)
+		} else if !expected && err == nil {
+			r.Failed = true
+			_, _ = fmt.Fprintf(r.Log, "expected %s not to be pingable from nginx, but was", host)
+		}
+	})
 }
 
 func testNetworkTcpReset(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_commons v1.10.3
+	github.com/steadybit/action-kit/go/action_kit_commons v1.10.4
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.4.0
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -225,10 +225,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdnI3ttxX96nF2JAEQSx/zM8IQGwDo=
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
-github.com/steadybit/action-kit/go/action_kit_commons v1.10.2 h1:IXewaRbwbFbzupFH8uwLRAPtEWyZQExhiKHpLtmG6Rw=
-github.com/steadybit/action-kit/go/action_kit_commons v1.10.2/go.mod h1:DW494MzDhf/gpdyzD07jo3c0Mqt2k8bBQqQEaOpy6Ns=
-github.com/steadybit/action-kit/go/action_kit_commons v1.10.3 h1:eNYGRoPfNp1bcoSYlhgui1DUGNKOEcYo9IJh68DSbrY=
-github.com/steadybit/action-kit/go/action_kit_commons v1.10.3/go.mod h1:wdTVhm9NDFiCJjHutRzgGmsxMJXF+jGsCBoeDpZs2l0=
+github.com/steadybit/action-kit/go/action_kit_commons v1.10.4 h1:DihqqBgQp3F+rluRCASGzpNHbClBz7z2XI0lV+eHz2g=
+github.com/steadybit/action-kit/go/action_kit_commons v1.10.4/go.mod h1:wdTVhm9NDFiCJjHutRzgGmsxMJXF+jGsCBoeDpZs2l0=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.4.0 h1:FPLsWpJ/mdMrZ8BaYXDOjcEvYs4U1EcXw04UQtom1Is=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.4.0/go.mod h1:NNpAxqUQOLZaEtaenRrOTBWKsFw9XcNaHzWPtF6EvF4=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=
@@ -314,8 +312,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
## What

Delivers the fix for network attacks not affecting protocols without ports (e.g. ICMP).

When no port is specified, the filter defaults to the any-port wildcard, which the blackhole attack previously rendered as `dport 1-65534` — matching only port-bearing protocols (TCP/UDP/SCTP) and letting ICMP escape. Fixed upstream in `action_kit_commons` v1.10.4 (steadybit/action-kit#472); this bumps the dependency and adds end-to-end coverage.

## Change

- `fix`: bump `action_kit_commons` to `v1.10.4`.
- `test(e2e)`: the blackhole e2e now pings a portless target and asserts it is blocked by a blackhole with no port set, and left reachable by a port-/host-scoped blackhole.

Verified locally: blackhole e2e passes against v1.10.4 (ICMP blocked when no port set, untouched when scoped).

Ref: BusinessMap 13054
