### PR TITLE
fix: use gcp.zone instead of google.zone as AZ fallback attribute

### DIFF
--- a/exthost/discovery.go
+++ b/exthost/discovery.go
@@ -61,7 +61,7 @@ func (d *hostDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "host.hostname"},
 				{Attribute: "host.ipv4"},
-				{Attribute: "aws.zone", FallbackAttributes: &[]string{"google.zone", "azure.zone"}},
+				{Attribute: "aws.zone", FallbackAttributes: &[]string{"gcp.zone", "azure.zone"}},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{
 				{


### PR DESCRIPTION
## Summary
- The `aws.zone` target attribute's fallback list referenced `google.zone`, but no extension ever sets that attribute — GCP zone data is published as `gcp.zone` (see extension-gcp, extension-gatling, extension-http, extension-jmeter, extension-k6). Fixes the fallback so it actually resolves on GCP hosts.

Related to BM #22908.

## Test plan
- [x] `go build ./...`
- [x] `go test ./exthost/...`