### PR TITLE
fix: make the rpm installable on Enterprise Linux 9

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,6 +112,9 @@ nfpms:
           - /usr/bin/dig
           - runc
           - libcap
-          - /usr/bin/cgexec
         recommends:
+          # cgexec (libcgroup-tools) is only needed for the fill memory attack when
+          # running without runc. There is no libcgroup package for EL9, so this must
+          # stay a weak dependency to keep the package installable on RHEL 9 & friends.
+          - /usr/bin/cgexec
           - kernel-modules-extra

--- a/exthost/action_fill_mem.go
+++ b/exthost/action_fill_mem.go
@@ -158,6 +158,12 @@ func (a *fillMemoryAction) Prepare(ctx context.Context, state *FillMemoryActionS
 		return nil, err
 	}
 
+	// memfill is placed into the target's memory cgroup using cgexec. The linux packages only
+	// recommend it (there is no libcgroup package for EL9), so fail early with a clear message.
+	if _, err := exec.LookPath("cgexec"); err != nil {
+		return nil, extension_kit.ToError("The fill memory attack requires the 'cgexec' binary (provided by the cgroup-tools or libcgroup-tools package), which was not found on this host. Please install it and retry.", err)
+	}
+
 	opts, err := fillMemoryOpts(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

The rpm hard-requires `/usr/bin/cgexec` (used by the fill memory attack to place memfill into the target's memory cgroup). `cgexec` is provided by `libcgroup-tools`, which **does not exist for EL9**: Red Hat removed libcgroup in RHEL 9 ([solution 7115132](https://access.redhat.com/solutions/7115132)) and it was never packaged for EPEL 9 (it exists in EPEL 7, 8 and 10). This makes `steadybit-extension-host` uninstallable on RHEL 9 / Rocky 9 / Alma 9:

```
Error: Problem: cannot install the best candidate for the job
 - nothing provides /usr/bin/cgexec needed by steadybit-extension-host-1.7.3-1
```

Reported by a customer installing on an Azure RHEL 9 VM.

## Changes

- Demote `/usr/bin/cgexec` from a hard rpm dependency to `recommends`: dnf installs weak dependencies where available and silently skips them where not, so the package installs on EL9 while still pulling in cgexec on distros that have it. The deb dependency on `cgroup-tools` is unchanged, and the container image already bundles it.
- Fail the fill memory attack early in `Prepare` with an actionable message when `cgexec` is missing, instead of a cryptic nsenter exec error at start. All other host attacks don't use cgexec and are unaffected.

Verified on a `rockylinux/rockylinux:9` container that every remaining rpm dependency resolves once EPEL is enabled (stress-ng 0.19.03 from EPEL 9, bind-utils, runc, iproute-tc, …). The installer-side EPEL fix is steadybit/setup-scripts#71 — its new rocky-9 CI test stays red until this change is released to packages.steadybit.com.

## Follow-up (not in this PR)

Long term the cgexec usage in `action_kit_commons/memfill` can be dropped entirely (join the cgroup via `cgroup.procs` or `nsenter --cgroup` with util-linux ≥ 2.39), which would restore the fill memory attack on EL9.