### PR TITLE
Revert "fix: make the rpm installable on Enterprise Linux 9 (#240)"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,9 +112,6 @@ nfpms:
           - /usr/bin/dig
           - runc
           - libcap
-        recommends:
-          # cgexec (libcgroup-tools) is only needed for the fill memory attack when
-          # running without runc. There is no libcgroup package for EL9, so this must
-          # stay a weak dependency to keep the package installable on RHEL 9 & friends.
           - /usr/bin/cgexec
+        recommends:
           - kernel-modules-extra

--- a/exthost/action_fill_mem.go
+++ b/exthost/action_fill_mem.go
@@ -158,12 +158,6 @@ func (a *fillMemoryAction) Prepare(ctx context.Context, state *FillMemoryActionS
 		return nil, err
 	}
 
-	// memfill is placed into the target's memory cgroup using cgexec. The linux packages only
-	// recommend it (there is no libcgroup package for EL9), so fail early with a clear message.
-	if _, err := exec.LookPath("cgexec"); err != nil {
-		return nil, extension_kit.ToError("The fill memory attack requires the 'cgexec' binary (provided by the cgroup-tools or libcgroup-tools package), which was not found on this host. Please install it and retry.", err)
-	}
-
 	opts, err := fillMemoryOpts(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Reverts #240 on `main`.

#240 was squash-merged, then we decided to hold it for review. This PR backs the change out of `main` so the EL9 packaging change is not shipped until it has been signed off.

**Why a revert PR instead of reopening #240:** GitHub cannot reopen a merged PR, and `main` is protected so the revert cannot be pushed directly. Merging this PR removes #240's changes from `main`; the original change is preserved on branch `fix/el9-installable-rpm` and re-proposed in the companion PR below.

**Decision for @head-of-engineering:** merge this to back the change out, or close it to keep #240 as-is. The re-land is prepared as a stacked PR (companion below) that auto-retargets to `main` once this merges.

Related: setup-scripts#71 (installer EPEL/CRB support) and action-kit#478 (the long-term fix that removes the cgexec dependency entirely) remain open and are unaffected by this revert.