### PR TITLE
Re-land: make the rpm installable on Enterprise Linux 9 (reopen of #240)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,6 +112,9 @@ nfpms:
           - /usr/bin/dig
           - runc
           - libcap
-          - /usr/bin/cgexec
         recommends:
+          # cgexec (libcgroup-tools) is only needed for the fill memory attack when
+          # running without runc. There is no libcgroup package for EL9, so this must
+          # stay a weak dependency to keep the package installable on RHEL 9 & friends.
+          - /usr/bin/cgexec
           - kernel-modules-extra

--- a/exthost/action_fill_mem.go
+++ b/exthost/action_fill_mem.go
@@ -158,6 +158,12 @@ func (a *fillMemoryAction) Prepare(ctx context.Context, state *FillMemoryActionS
 		return nil, err
 	}
 
+	// memfill is placed into the target's memory cgroup using cgexec. The linux packages only
+	// recommend it (there is no libcgroup package for EL9), so fail early with a clear message.
+	if _, err := exec.LookPath("cgexec"); err != nil {
+		return nil, extension_kit.ToError("The fill memory attack requires the 'cgexec' binary (provided by the cgroup-tools or libcgroup-tools package), which was not found on this host. Please install it and retry.", err)
+	}
+
 	opts, err := fillMemoryOpts(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Re-proposes the change from #240, which was merged and then reverted (#241) pending review.

#240 itself cannot be reopened because GitHub does not allow reopening a merged PR, so this is a fresh PR from the same, unchanged branch (`fix/el9-installable-rpm`). The content is identical to #240.

**Stacked on the revert:** base is `revert-el9-rpm-240` (PR #241) so the diff shows exactly #240's change on top of the revert. When #241 merges into `main`, GitHub auto-retargets this PR to `main`.

**For @head-of-engineering:** this is the change to review/re-land. Original discussion and review history are on #240.

### Original description (from #240)

Demote `/usr/bin/cgexec` from a hard rpm dependency to `recommends` so `steadybit-extension-host` installs on RHEL 9 / Rocky 9 / Alma 9 (no libcgroup package exists for EL9), and fail the fill memory attack early with a clear message when cgexec is missing. The deb dependency on `cgroup-tools` is unchanged.

Note: the long-term fix in action-kit#478 removes the cgexec dependency entirely; once that is released this packaging workaround can be superseded.