### PR TITLE
fix(linuxpkg): add missing iptables/fallocate rpm deps, drop unused ps

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,12 +63,18 @@ nfpms:
     builds:
       - steadybit-extension-host
     dependencies:
+      # procps provides /usr/bin/kill on debian/ubuntu, which the process
+      # runners use to signal stress-ng / memfill / diskfill / dns-inject.
       - procps
       - stress-ng
+      # iptables-restore / ip6tables-restore: network delay + tcp reset
       - iptables
+      # ip + tc
       - iproute2
+      # dig: resolving the network attack's target hostnames
       - bind9-dnsutils
       - runc
+      # capsh, used by the sysv init.d script
       - libcap2-bin
     bindir: /opt/steadybit/extension-host
     contents:
@@ -104,10 +110,11 @@ nfpms:
     overrides:
       rpm:
         dependencies:
-          - /usr/bin/ps
           - /usr/bin/stress-ng
           - iproute-tc
           - /usr/sbin/ip
+          - /usr/sbin/iptables-restore
+          - /usr/bin/fallocate
           - /usr/bin/dig
           - runc
           - libcap


### PR DESCRIPTION
## What

Fixes the `nfpms` dependency list for the deb/rpm packages.

**rpm — added two missing dependencies:**

| dep | provided by (EL9) | why |
| --- | --- | --- |
| `/usr/sbin/iptables-restore` | `iptables-nft` | `netfault` pipes its rules through `iptables-restore` / `ip6tables-restore` for the **network delay** and **tcp reset** attacks |
| `/usr/bin/fallocate` | `util-linux` (not `util-linux-core`!) | `diskfill` execs `fallocate` for **fill disk** with method "at once" |

Neither is guaranteed on a minimal Enterprise Linux host, so both attacks could fail after a plain `dnf install`. The deb already declares `iptables`, and `fallocate` comes from the essential `util-linux` there, so the deb list is unchanged.

**rpm — removed `/usr/bin/ps`:**

Nothing shells out to `ps` or `pkill` — process listing is pure Go (`mitchellh/go-ps`). The binary we *do* exec is `kill` (to signal stress-ng / memfill / diskfill / dns-inject), and on Enterprise Linux that comes from `util-linux-core`, which is always installed. So `procps-ng` was being pulled in for nothing.

On debian/ubuntu `procps` **stays**: it is the only provider of `/usr/bin/kill` there (`debian:13-slim` ships no `kill` at all). Added a comment so this asymmetry doesn't look like an oversight.

`libcap` / `libcap2-bin` stays a hard dependency — `capsh` is used by the SysV `init.d` script — now with a comment saying so.

## Verification

- Package providers confirmed in `almalinux:9` and `debian:13-slim` containers.
- `goreleaser check` passes (only the pre-existing `nfpms.builds` deprecation warning).