### PR TITLE
fix: extract dns-inject straight to its arch-suffixed path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
       - -X github.com/steadybit/extension-kit/extbuild.Version={{.Version}}
       - -X github.com/steadybit/extension-kit/extbuild.Revision={{.Commit}}
     hooks:
-      post: sh -c "curl -sfL \"https://github.com/steadybit/nsmount/releases/download/${NSMOUNT_VERSION}/nsmount.{{ .Arch }}\" -o \"./dist/nsmount.{{ .Arch }}\" && chmod a+x \"./dist/nsmount.{{ .Arch }}\" && curl -sfL \"https://github.com/steadybit/memfill/releases/download/${MEMFILL_VERSION}/memfill.{{ .Arch }}\" -o \"./dist/memfill.{{ .Arch }}\" && chmod a+x \"./dist/memfill.{{ .Arch }}\" && curl -sfL \"https://github.com/steadybit/dns-inject/releases/download/${DNS_INJECT_VERSION}/dns-inject_${DNS_INJECT_VERSION#v}_{{ .Arch }}.tar.gz\" | tar -xzf - -C ./dist dns-inject && mv ./dist/dns-inject \"./dist/dns-inject.{{ .Arch }}\" && chmod a+x \"./dist/dns-inject.{{ .Arch }}\""
+      post: sh -c "curl -sfL \"https://github.com/steadybit/nsmount/releases/download/${NSMOUNT_VERSION}/nsmount.{{ .Arch }}\" -o \"./dist/nsmount.{{ .Arch }}\" && chmod a+x \"./dist/nsmount.{{ .Arch }}\" && curl -sfL \"https://github.com/steadybit/memfill/releases/download/${MEMFILL_VERSION}/memfill.{{ .Arch }}\" -o \"./dist/memfill.{{ .Arch }}\" && chmod a+x \"./dist/memfill.{{ .Arch }}\" && curl -sfL \"https://github.com/steadybit/dns-inject/releases/download/${DNS_INJECT_VERSION}/dns-inject_${DNS_INJECT_VERSION#v}_{{ .Arch }}.tar.gz\" | tar -xzOf - dns-inject > \"./dist/dns-inject.{{ .Arch }}\" && chmod a+x \"./dist/dns-inject.{{ .Arch }}\""
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
Fixes a race in the goreleaser `post` build hook that intermittently fails `Build Linux Packages`.

### The bug

The hook runs **once per build target, concurrently** for amd64 and arm64. Both invocations extracted the `dns-inject` member to the *same* unsuffixed path and only then renamed it to the arch-suffixed one:

```
tar -xzf - -C ./dist dns-inject && mv ./dist/dns-inject "./dist/dns-inject.{{ .Arch }}"
```

Whichever target reached the `mv` first won; the loser found nothing left to move and failed with:

```
post hook failed: exit status 1
output=mv: cannot stat './dist/dns-inject': No such file or directory
```

The sibling `nsmount` and `memfill` downloads were never affected — they `curl -o` straight to an arch-suffixed name. Only `dns-inject`, which goes through a tarball, shared a path.

### Evidence it is a race

On extension-host `main`, run `32130762750` failed this way twice with **different** targets losing:

- attempt 1 → `target=linux_arm64_v8.0`
- attempt 2 → `target=linux_amd64_v1`

with both hooks starting ~5 ms apart. A deterministic problem (missing asset, wrong tarball layout) would fail the same target every time, and would fail at `tar`, not at `mv`.

### The fix

Stream the member to stdout and redirect it to its final name, so the two targets never share a path:

```
tar -xzOf - dns-inject > "./dist/dns-inject.{{ .Arch }}"
```

This also drops the `mv` entirely, matching how `nsmount`/`memfill` are already handled. A failing `curl` or `tar` still short-circuits the hook through `&&`, so real download failures remain loud.

### Verification

Confirmed the `dns-inject` member sits at the tarball root for both arches, and ran the new command for amd64 and arm64 **concurrently**: both files are produced, each a correct-architecture ELF binary (`x86-64` and `ARM aarch64`), where the old command reliably lost one of them.