### PR TITLE
build: install bind9-dnsutils instead of the virtual dnsutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 
 RUN apt-get -qq update \
     && apt-get -qq upgrade -y \
-    && apt-get -qq install -y --no-install-recommends procps stress-ng iptables iproute2 dnsutils libcap2-bin util-linux \
+    && apt-get -qq install -y --no-install-recommends procps stress-ng iptables iproute2 bind9-dnsutils libcap2-bin util-linux \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /run/systemd/system /sidecar


### PR DESCRIPTION
## What

The runtime image installs `dnsutils` to get `dig`. Since the bind9 9.16 packaging split, `dig` lives in **`bind9-dnsutils`** — which is what the deb package already depends on (`.goreleaser.yaml`). This aligns the Dockerfile with it.

## Why it matters

On the image's own base, `debian:13-slim`, `dnsutils` is a **pure virtual package**:

```
$ docker run --rm debian:13-slim apt-cache policy dnsutils
dnsutils:
  Installed: (none)
  Candidate: (none)          # <-- no version at all
```

`apt-get install dnsutils` works there only because apt resolves a virtual package when exactly *one* package provides it, and `bind9-dnsutils` is currently the sole provider (`apt-get install -s dnsutils` confirms that is what gets pulled). A second provider appearing, or Debian dropping the `Provides`, turns the build into `Package 'dnsutils' has no installation candidate`.

## Compatibility

`bind9-dnsutils` is a real, versioned package everywhere still supported — checked by querying apt in each image:

| Release | `bind9-dnsutils` | `dnsutils` |
| --- | --- | --- |
| Ubuntu 20.04 | 1:9.18.30 | 1:9.18.30 |
| Ubuntu 22.04 | 1:9.18.39 | 1:9.18.39 |
| Debian 11 | 1:9.16.50 | 1:9.16.50 |
| Debian 12 | 1:9.18.49 | 1:9.18.49 |
| Debian 13 | 1:9.20.26 | no candidate (virtual) |

Only Debian 10 / Ubuntu 18.04 ever had `dnsutils` alone, and both are long EOL.

## Verification

Installed the full new package list in `debian:13-slim` and confirmed every binary the extension execs is present: `dig` → `/usr/bin/dig`, plus `ip`, `tc`, `iptables-restore`, `fallocate`, `capsh`, `stress-ng`.

No runtime behaviour change — the same package ends up installed either way today. Prefixed `build:` so it doesn't trigger a patch release on its own.